### PR TITLE
feat: added timed token validator

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,8 @@
 include: package:flutter_lints/flutter.yaml
 analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
   errors:
     invalid_annotation_target: ignore
 linter:

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/features/authentication/data/auth_repository.dart
+++ b/lib/features/authentication/data/auth_repository.dart
@@ -1,5 +1,7 @@
+import "package:amaterasu/features/authentication/data/exceptions/twitch_auth_api_exceptions.dart";
 import "package:amaterasu/features/authentication/data/sources/secure_storage_data_source.dart";
 import "package:amaterasu/features/authentication/data/sources/twitch_auth_api_data_source.dart";
+import "package:amaterasu/features/authentication/domain/credentials.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 class AuthRepository {
@@ -10,16 +12,17 @@ class AuthRepository {
       : _twitchAuthApiDataSource = ref.watch(twitchAuthApiDataSourceProvider),
         _secureStorageDataSource = ref.watch(secureStorageDataSourceProvider);
 
-  String? _cachedToken;
+  Credentials? _cachedCredentials;
 
-  /// Prompts the user to authorize the application.
+  /// Creates new [Credentials] for the user.
   ///
-  /// This method will open a web browser and prompt the user to log in to their
-  /// Twitch account and authorize the application. After the user accepts, the
-  /// application will receive an access token to make requests to the Twitch API
-  /// on behalf of the user.
+  /// If `isAnonymous` is `true`, the user will be logged in anonymously.
   ///
-  /// The access token is then stored in the secure storage of the device.
+  /// Otherwise, this method will open a web browser and prompt the user to log
+  /// in to their Twitch account and authorize the application. After the user
+  /// accepts, the application will receive an access token to make requests to
+  /// the Twitch API on behalf of the user. The access token is then stored in the secure
+  /// storage of the device.
   ///
   /// Throws a [AuthorizationCancelledException] if the user cancelled the
   /// authorization process.
@@ -31,12 +34,24 @@ class AuthRepository {
   /// Throws a [MalformedCallbackException] if the callback URL returned by the
   /// Twitch API does not contain an access token.
   ///
+  /// Throws a [APIResponseException] if the Twitch API returned a non success status
+  /// code when validating the token.
+  ///
   /// Throws a [StorageException] if the access token could not be stored in the
   /// secure storage of the device.
-  Future<void> authorize() async {
+  Future<Credentials> addCredentials({isAnonymous = false}) async {
+    // If the user is signing in anonymously, we don't need to request an access token from the Twitch API.
+    if (isAnonymous) return _cachedCredentials = const Credentials.anonymous();
+
     final token = await _twitchAuthApiDataSource.authorizeClient();
+    final tokenInformation = await _twitchAuthApiDataSource.validateToken(token);
     await _secureStorageDataSource.writeAccessToken(token);
-    _cachedToken = token;
+    return _cachedCredentials = Credentials.user(
+      clientId: tokenInformation.clientId,
+      accessToken: token,
+      login: tokenInformation.login,
+      userId: tokenInformation.userId,
+    );
   }
 
   /// Revokes the access token authorization for the client.
@@ -46,14 +61,21 @@ class AuthRepository {
   ///
   /// The access token is then stored in the secure storage of the device.
   ///
+  /// Throws a [APIResponseException] if the Twitch API returned a non success status
+  /// code when revoking the token or getting the token information.
+  ///
   /// Throws a [StorageException] if the access token could not be removed from the
   /// secure storage of the device.
-  Future<void> revoke() async {
-    final token = _cachedToken;
-    if (token != null) {
+  Future<void> deleteCredentials({bool revoke = true}) async {
+    final credentials = await retrieveCredentials();
+    if (credentials == null) return;
+    if (credentials is UserCredentials) {
+      if (revoke) {
+        await _twitchAuthApiDataSource.revokeToken(credentials.accessToken, clientId: credentials.clientId);
+      }
       await _secureStorageDataSource.deleteAccessToken();
-      _cachedToken = null;
     }
+    _cachedCredentials = null;
   }
 
   /// Retrieves the access token used to make requests to the Twitch API.
@@ -66,11 +88,44 @@ class AuthRepository {
   ///
   /// Returns the access token if it was successfully retrieved or null if it was
   /// not found.
-  Future<String?> retrieveCurrentAccessToken() async {
-    if (_cachedToken != null) return _cachedToken;
+  Future<Credentials?> retrieveCredentials() async {
+    if (_cachedCredentials != null) return _cachedCredentials;
+
     final token = await _secureStorageDataSource.readAccessToken();
-    _cachedToken = token;
-    return token;
+    if (token == null) return null;
+
+    // If the access token is invalid, we delete it from the secure storage.
+    try {
+      final tokenInformation = await _twitchAuthApiDataSource.validateToken(token);
+      return _cachedCredentials = Credentials.user(
+        clientId: tokenInformation.clientId,
+        accessToken: token,
+        login: tokenInformation.login,
+        userId: tokenInformation.userId,
+      );
+    } on APIResponseException catch (e) {
+      if (e.statusCode == 401) {
+        await _secureStorageDataSource.deleteAccessToken();
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  Future<bool> isCredentialsValid() async {
+    final credentials = _cachedCredentials;
+    if (credentials == null) return false;
+
+    if (credentials is UserCredentials) {
+      try {
+        await _twitchAuthApiDataSource.validateToken(credentials.accessToken);
+        return true;
+      } on APIResponseException catch (e) {
+        if (e.statusCode == 401) return false;
+        rethrow;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/features/authentication/data/exceptions/twitch_auth_api_exceptions.dart
+++ b/lib/features/authentication/data/exceptions/twitch_auth_api_exceptions.dart
@@ -3,3 +3,9 @@ class MalformedCallbackException implements Exception {}
 class AuthorizationCancelledException implements Exception {}
 
 class StateMismatchException implements Exception {}
+
+class APIResponseException implements Exception {
+  final int statusCode;
+
+  APIResponseException(this.statusCode);
+}

--- a/lib/features/authentication/data/responses/validate_token_response.dart
+++ b/lib/features/authentication/data/responses/validate_token_response.dart
@@ -1,0 +1,18 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "validate_token_response.freezed.dart";
+part "validate_token_response.g.dart";
+
+@freezed
+class ValidateTokenResponse with _$ValidateTokenResponse {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory ValidateTokenResponse({
+    required String clientId,
+    required String login,
+    required String userId,
+    required List<String> scopes,
+    required int expiresIn,
+  }) = _ValidateTokenResponse;
+
+  factory ValidateTokenResponse.fromJson(Map<String, dynamic> json) => _$ValidateTokenResponseFromJson(json);
+}

--- a/lib/features/authentication/data/sources/twitch_auth_api_data_source.dart
+++ b/lib/features/authentication/data/sources/twitch_auth_api_data_source.dart
@@ -2,12 +2,17 @@ import "dart:convert";
 import "dart:math";
 
 import "package:amaterasu/features/authentication/data/exceptions/twitch_auth_api_exceptions.dart";
+import "package:amaterasu/features/authentication/data/responses/validate_token_response.dart";
 import "package:flutter/services.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:flutter_web_auth_2/flutter_web_auth_2.dart";
+import "package:http/http.dart";
 
+/// Data source for interacting with the Twitch Auth API.
+///
+/// The Twitch Auth API (id.twitch.tv) provides oauth2 authentication for the Twitch API.
 class TwitchAuthApiDataSource {
-  static const String _clientId = "smff7b2spurx6aq29h8sfevqiee8uv";
+  static const String _defaultClientId = "smff7b2spurx6aq29h8sfevqiee8uv";
   static const List<String> _requiredScopes = [
     "user:read:follows",
     "user:read:subscriptions",
@@ -19,6 +24,10 @@ class TwitchAuthApiDataSource {
     "whispers:read",
     "whispers:edit",
   ];
+
+  final Client _http;
+
+  TwitchAuthApiDataSource(this._http);
 
   /// Requests an access token from the Twitch API.
   ///
@@ -37,12 +46,12 @@ class TwitchAuthApiDataSource {
   /// Twitch API does not contain an access token.
   ///
   /// Returns the access token if the request was successful.
-  Future<String> authorizeClient({String clientId = _clientId, String redirectScheme = "amtsu"}) async {
+  Future<String> authorizeClient({String clientId = _defaultClientId}) async {
     // Generate a random state token to prevent CSRF attacks.
     final stateToken = base64UrlEncode(List.generate(32, (i) => Random().nextInt(256))).replaceAll("[^A-Za-z0-9]", "");
     final authorizationUrl = Uri.https("id.twitch.tv", "/oauth2/authorize", {
       "client_id": clientId,
-      "redirect_uri": "$redirectScheme://",
+      "redirect_uri": "amtsu://",
       "response_type": "token",
       "force_verify": "true",
       "scope": _requiredScopes.join(" "),
@@ -51,7 +60,7 @@ class TwitchAuthApiDataSource {
 
     try {
       // Prompt the user to authorize the application and wait for the callback.
-      final result = await FlutterWebAuth2.authenticate(url: authorizationUrl, callbackUrlScheme: redirectScheme);
+      final result = await FlutterWebAuth2.authenticate(url: authorizationUrl, callbackUrlScheme: "amtsu");
 
       // After we recieve the callback extract the access token from the URL.
       final callback = Uri.parse(result);
@@ -72,8 +81,43 @@ class TwitchAuthApiDataSource {
       throw AuthorizationCancelledException();
     }
   }
+
+  /// Validates the provided `accessToken` with the Twitch API.
+  ///
+  /// Throws a [APIResponseException] if the Twitch API returns a status code
+  /// other than 200.
+  ///
+  /// Returns a [ValidateTokenResponse] containing information about the token
+  /// if the request was successful.
+  Future<ValidateTokenResponse> validateToken(String accessToken) async {
+    final route = Uri.https("id.twitch.tv", "/oauth2/validate");
+    final response = await _http.get(route, headers: {"Authorization": "OAuth $accessToken"});
+
+    if (response.statusCode != 200) {
+      throw APIResponseException(response.statusCode);
+    }
+
+    return ValidateTokenResponse.fromJson(json.decode(response.body));
+  }
+
+  /// Revokes the provided `accessToken` with the Twitch API.
+  ///
+  /// The Twitch API will invalidate the token and it will no longer be usable by
+  /// the `clientId`.
+  ///
+  /// Throws a [APIResponseException] if the Twitch API returns a status code
+  /// other than 200.
+  Future<void> revokeToken(String accessToken, {required String clientId}) async {
+    final route = Uri.https("id.twitch.tv", "/oauth2/revoke");
+    final response = await _http.post(route, body: {"client_id": clientId, "token": accessToken});
+
+    if (response.statusCode != 200) {
+      throw APIResponseException(response.statusCode);
+    }
+  }
 }
 
 final twitchAuthApiDataSourceProvider = Provider<TwitchAuthApiDataSource>((ref) {
-  return TwitchAuthApiDataSource();
+  final client = Client();
+  return TwitchAuthApiDataSource(client);
 });

--- a/lib/features/authentication/domain/credentials.dart
+++ b/lib/features/authentication/domain/credentials.dart
@@ -1,0 +1,15 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "credentials.freezed.dart";
+
+@freezed
+class Credentials with _$Credentials {
+  const factory Credentials.user({
+    required String clientId,
+    required String accessToken,
+    required String login,
+    required String userId,
+  }) = UserCredentials;
+
+  const factory Credentials.anonymous() = AnonymousCredentials;
+}

--- a/lib/features/authentication/presentation/auth_controller.dart
+++ b/lib/features/authentication/presentation/auth_controller.dart
@@ -1,30 +1,63 @@
+import "dart:async";
+
 import "package:amaterasu/features/authentication/data/auth_repository.dart";
+import "package:amaterasu/features/authentication/domain/credentials.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 part "auth_controller.g.dart";
 
 @riverpod
 class AuthController extends _$AuthController {
+  static const Duration _validationRefreshInterval = Duration(hours: 1);
+
   late AuthRepository _authRepository;
 
+  Timer? _validationTimer;
+
   @override
-  Future<String?> build() async {
+  Future<Credentials?> build() async {
     _authRepository = ref.watch(authRepositoryProvider);
 
-    return _authRepository.retrieveCurrentAccessToken();
+    final credentials = await _authRepository.retrieveCredentials();
+    if (credentials != null && credentials is UserCredentials) _startValidationTimer();
+    return credentials;
   }
 
-  Future<void> login() async {
+  Future<void> connectTwitchAccount() async {
+    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      await _authRepository.authorize();
-      return _authRepository.retrieveCurrentAccessToken();
+      final credentials = await _authRepository.addCredentials();
+      _startValidationTimer();
+      return credentials;
     });
   }
 
-  Future<void> logout() async {
+  Future<void> removeTwitchAccount() async {
+    state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      await _authRepository.revoke();
+      await _authRepository.deleteCredentials();
+      _stopValidationTimer();
       return null;
+    });
+  }
+
+  void _stopValidationTimer() {
+    _validationTimer?.cancel();
+    _validationTimer = null;
+  }
+
+  void _startValidationTimer() {
+    _validationTimer?.cancel();
+    _validationTimer = Timer.periodic(_validationRefreshInterval, (timer) async {
+      try {
+        final isValid = await _authRepository.isCredentialsValid();
+        if (!isValid) {
+          await _authRepository.deleteCredentials(revoke: false);
+          _stopValidationTimer();
+        }
+      } catch (e) {
+        state = AsyncError(e, StackTrace.current);
+      }
     });
   }
 

--- a/lib/features/authentication/presentation/login_button.dart
+++ b/lib/features/authentication/presentation/login_button.dart
@@ -10,7 +10,7 @@ class LoginButton extends ConsumerWidget {
     return SizedBox(
       height: 32,
       child: ElevatedButton(
-        onPressed: () async => ref.read(authControllerProvider.notifier).login(),
+        onPressed: () async => ref.read(authControllerProvider.notifier).connectTwitchAccount(),
         child: const Text("Connect with Twitch"),
       ),
     );

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -11,7 +11,8 @@ class HomeScreen extends ConsumerWidget {
       body: const Text("Home"),
       persistentFooterButtons: [
         ElevatedButton(
-            onPressed: () async => ref.read(authControllerProvider.notifier).logout(), child: const Text("Sign out"))
+            onPressed: () async => ref.read(authControllerProvider.notifier).removeTwitchAccount(),
+            child: const Text("Sign out"))
       ],
     );
   }


### PR DESCRIPTION
Twitch requires applications using the api to verify the token hourly see(https://dev.twitch.tv/docs/authentication/validate-tokens). This PR adds a validation timer to the auth controller as well as a revoke method so when the user signs out the token is no longer valid.

AuthController state now uses Credentials union which can represent an authenticated user or anonymous for when the user just wants read access to a chat room.